### PR TITLE
Fix imports for top-level package usage

### DIFF
--- a/src/optimization/strategy_factory.py
+++ b/src/optimization/strategy_factory.py
@@ -8,72 +8,49 @@ and their hyperparameter spaces for optimization.
 from typing import Dict, List, Type, Any, Tuple, Optional
 from abc import ABC, abstractmethod
 
-# Use absolute imports
-try:
-    from src.strategies.base_strategy import BaseStrategy
-    from src.strategies.moving_average_crossover import MovingAverageCrossoverStrategy
-    from src.strategies.macd_strategy import MACDStrategy
-    from src.strategies.rsi_strategy import RSIStrategy
-    from src.strategies.bollinger_bands_strategy import BollingerBandsStrategy
-    from src.strategies.momentum_strategy import MomentumStrategy
-    # Volume-based strategies
-    from src.strategies.vwap_strategy import VWAPStrategy
-    from src.strategies.obv_strategy import OBVStrategy
-    from src.strategies.ad_strategy import ADStrategy
-    from src.strategies.cmf_strategy import CMFStrategy
-    # Volatility-based strategies
-    from src.strategies.atr_strategy import ATRStrategy
-    from src.strategies.bollinger_squeeze_strategy import BollingerSqueezeStrategy
-    from src.strategies.keltner_channel_strategy import KeltnerChannelStrategy
-    from src.strategies.historical_volatility_strategy import HistoricalVolatilityStrategy
-    # Advanced momentum strategies
-    from src.strategies.roc_strategy import ROCStrategy
-    from src.strategies.stochastic_strategy import StochasticStrategy
-    from src.strategies.williams_r_strategy import WilliamsRStrategy
-    from src.strategies.ultimate_oscillator_strategy import UltimateOscillatorStrategy
-    # Pattern recognition strategies
-    from src.strategies.support_resistance_strategy import SupportResistanceStrategy
-    from src.strategies.pivot_points_strategy import PivotPointsStrategy
-    from src.strategies.fibonacci_retracement_strategy import FibonacciRetracementStrategy
-    from src.strategies.double_top_bottom_strategy import DoubleTopBottomStrategy
-    # Multi-timeframe strategies
-    from src.strategies.mtf_trend_analysis_strategy import MTFTrendAnalysisStrategy
-    from src.strategies.mtf_rsi_strategy import MTFRSIStrategy
-    from src.strategies.mtf_macd_strategy import MTFMACDStrategy
-    from src.utils.logger import get_logger
-except ImportError:
-    # Fallback for relative imports when running as module
-    from ..strategies.base_strategy import BaseStrategy
-    from ..strategies.moving_average_crossover import MovingAverageCrossoverStrategy
-    from ..strategies.macd_strategy import MACDStrategy
-    from ..strategies.rsi_strategy import RSIStrategy
-    from ..strategies.bollinger_bands_strategy import BollingerBandsStrategy
-    from ..strategies.momentum_strategy import MomentumStrategy
-    # Volume-based strategies
-    from ..strategies.vwap_strategy import VWAPStrategy
-    from ..strategies.obv_strategy import OBVStrategy
-    from ..strategies.ad_strategy import ADStrategy
-    from ..strategies.cmf_strategy import CMFStrategy
-    # Volatility-based strategies
-    from ..strategies.atr_strategy import ATRStrategy
-    from ..strategies.bollinger_squeeze_strategy import BollingerSqueezeStrategy
-    from ..strategies.keltner_channel_strategy import KeltnerChannelStrategy
-    from ..strategies.historical_volatility_strategy import HistoricalVolatilityStrategy
-    # Advanced momentum strategies
-    from ..strategies.roc_strategy import ROCStrategy
-    from ..strategies.stochastic_strategy import StochasticStrategy
-    from ..strategies.williams_r_strategy import WilliamsRStrategy
-    from ..strategies.ultimate_oscillator_strategy import UltimateOscillatorStrategy
-    # Pattern recognition strategies
-    from ..strategies.support_resistance_strategy import SupportResistanceStrategy
-    from ..strategies.pivot_points_strategy import PivotPointsStrategy
-    from ..strategies.fibonacci_retracement_strategy import FibonacciRetracementStrategy
-    from ..strategies.double_top_bottom_strategy import DoubleTopBottomStrategy
-    # Multi-timeframe strategies
-    from ..strategies.mtf_trend_analysis_strategy import MTFTrendAnalysisStrategy
-    from ..strategies.mtf_rsi_strategy import MTFRSIStrategy
-    from ..strategies.mtf_macd_strategy import MTFMACDStrategy
-    from ..utils.logger import get_logger
+# Import strategy implementations and utilities.  Using absolute imports here
+# avoids issues when the package is imported either as ``optimization`` or
+# ``src.optimization``.  Both layouts occur in this repository (for example in
+# tests we import ``optimization.strategy_factory`` directly).  Attempting
+# relative imports would fail when ``optimization`` is a top-level package.
+
+from strategies.base_strategy import BaseStrategy
+from strategies.moving_average_crossover import MovingAverageCrossoverStrategy
+from strategies.macd_strategy import MACDStrategy
+from strategies.rsi_strategy import RSIStrategy
+from strategies.bollinger_bands_strategy import BollingerBandsStrategy
+from strategies.momentum_strategy import MomentumStrategy
+
+# Volume-based strategies
+from strategies.vwap_strategy import VWAPStrategy
+from strategies.obv_strategy import OBVStrategy
+from strategies.ad_strategy import ADStrategy
+from strategies.cmf_strategy import CMFStrategy
+
+# Volatility-based strategies
+from strategies.atr_strategy import ATRStrategy
+from strategies.bollinger_squeeze_strategy import BollingerSqueezeStrategy
+from strategies.keltner_channel_strategy import KeltnerChannelStrategy
+from strategies.historical_volatility_strategy import HistoricalVolatilityStrategy
+
+# Advanced momentum strategies
+from strategies.roc_strategy import ROCStrategy
+from strategies.stochastic_strategy import StochasticStrategy
+from strategies.williams_r_strategy import WilliamsRStrategy
+from strategies.ultimate_oscillator_strategy import UltimateOscillatorStrategy
+
+# Pattern recognition strategies
+from strategies.support_resistance_strategy import SupportResistanceStrategy
+from strategies.pivot_points_strategy import PivotPointsStrategy
+from strategies.fibonacci_retracement_strategy import FibonacciRetracementStrategy
+from strategies.double_top_bottom_strategy import DoubleTopBottomStrategy
+
+# Multi-timeframe strategies
+from strategies.mtf_trend_analysis_strategy import MTFTrendAnalysisStrategy
+from strategies.mtf_rsi_strategy import MTFRSIStrategy
+from strategies.mtf_macd_strategy import MTFMACDStrategy
+
+from utils.logger import get_logger
 
 
 class StrategyRegistry:

--- a/src/strategies/ad_strategy.py
+++ b/src/strategies/ad_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class ADStrategy(BaseStrategy):

--- a/src/strategies/atr_strategy.py
+++ b/src/strategies/atr_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class ATRStrategy(BaseStrategy):

--- a/src/strategies/backtesting_engine.py
+++ b/src/strategies/backtesting_engine.py
@@ -14,7 +14,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .base_strategy import BaseStrategy, Signal, Position
-from ..utils.logger import get_logger, log_performance
+from utils.logger import get_logger, log_performance
 
 
 @dataclass

--- a/src/strategies/base_strategy.py
+++ b/src/strategies/base_strategy.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import logging
 
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 @dataclass

--- a/src/strategies/bollinger_bands_strategy.py
+++ b/src/strategies/bollinger_bands_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class BollingerBandsStrategy(BaseStrategy):

--- a/src/strategies/bollinger_squeeze_strategy.py
+++ b/src/strategies/bollinger_squeeze_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class BollingerSqueezeStrategy(BaseStrategy):

--- a/src/strategies/cmf_strategy.py
+++ b/src/strategies/cmf_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class CMFStrategy(BaseStrategy):

--- a/src/strategies/historical_volatility_strategy.py
+++ b/src/strategies/historical_volatility_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class HistoricalVolatilityStrategy(BaseStrategy):

--- a/src/strategies/keltner_channel_strategy.py
+++ b/src/strategies/keltner_channel_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class KeltnerChannelStrategy(BaseStrategy):

--- a/src/strategies/macd_strategy.py
+++ b/src/strategies/macd_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class MACDStrategy(BaseStrategy):

--- a/src/strategies/momentum_strategy.py
+++ b/src/strategies/momentum_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class MomentumStrategy(BaseStrategy):

--- a/src/strategies/moving_average_crossover.py
+++ b/src/strategies/moving_average_crossover.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class MovingAverageCrossoverStrategy(BaseStrategy):

--- a/src/strategies/mtf_macd_strategy.py
+++ b/src/strategies/mtf_macd_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional, List, Tuple
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class MTFMACDStrategy(BaseStrategy):

--- a/src/strategies/mtf_rsi_strategy.py
+++ b/src/strategies/mtf_rsi_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional, List, Tuple
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class MTFRSIStrategy(BaseStrategy):

--- a/src/strategies/mtf_trend_analysis_strategy.py
+++ b/src/strategies/mtf_trend_analysis_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional, List, Tuple
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class MTFTrendAnalysisStrategy(BaseStrategy):

--- a/src/strategies/obv_strategy.py
+++ b/src/strategies/obv_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class OBVStrategy(BaseStrategy):

--- a/src/strategies/roc_strategy.py
+++ b/src/strategies/roc_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class ROCStrategy(BaseStrategy):

--- a/src/strategies/rsi_strategy.py
+++ b/src/strategies/rsi_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class RSIStrategy(BaseStrategy):

--- a/src/strategies/stochastic_strategy.py
+++ b/src/strategies/stochastic_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class StochasticStrategy(BaseStrategy):

--- a/src/strategies/ultimate_oscillator_strategy.py
+++ b/src/strategies/ultimate_oscillator_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class UltimateOscillatorStrategy(BaseStrategy):

--- a/src/strategies/vwap_strategy.py
+++ b/src/strategies/vwap_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class VWAPStrategy(BaseStrategy):

--- a/src/strategies/williams_r_strategy.py
+++ b/src/strategies/williams_r_strategy.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, Optional
 import ta
 
 from .base_strategy import BaseStrategy, Signal
-from ..utils.logger import get_logger
+from utils.logger import get_logger
 
 
 class WilliamsRStrategy(BaseStrategy):


### PR DESCRIPTION
## Summary
- update `StrategyFactory` to always use absolute imports
- update all strategies to import logger with an absolute path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b7f3bdb88332a32ecc29bc0a668e